### PR TITLE
Documents Markdown inside a HAML template.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -369,6 +369,14 @@ that's a maintenance nightmare and won't work.
 On a related topic: if your Markdown gem has a `lib/markdown.rb` file that
 monkeypatches the Markdown class, you're a terrible human being. Just saying.
 
+With HAML
+------------------
+Markdown inside a HAML template has to be forced to preserve indenting for code blocks by:
+~~~~~ ruby
+%article= preserve do
+  Redcarpet::Markdown.new(Redcarpet::Render::HTML, fenced_code_blocks: true)
+~~~~~
+
 Boring legal stuff
 ------------------
 


### PR DESCRIPTION
Documentation has to be enhanced because it is hard to find a solution how to deal with the broken Markdown code indenting inside HAML templates by default. The whitespaces have to be preserved explicitly by calling HAML#preserve.
